### PR TITLE
Fixes #26 Current destination is discovered much faster now on app launch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ### Fixes
 
+- [#26](https://github.com/AdamKobus/compose-navigation/issues/26) `NavDestinationManager.currentDestination` change to the first visible
+  screen happens instantly on app launch now.
+  
 ### Changes
 
 - Updated dependencies
@@ -9,7 +12,7 @@
 - Improved the current destination evaluation code
 - Prepared the code for handling nested / multiple NavHosts
 - `INavAction` now has 2 different implementations: `NavigateAction` and `PopAction`
-- `INavDestination` now has 3 different implementations: `NavGraph`, `NavDestination` and `PopDestination`. This makes it easy to determine 
+- `INavDestination` now has 3 different implementations: `NavGraph`, `NavDestination` and `PopDestination`. This makes it easy to determine
   which type of action should be performed.
 - `NavActionWrapper` is now an abstract class so that there is less boilerplate code in NavActions declarations using sealed classes.
 - `NavGraph` is now an abstract class that requires `name` to be passed in constructor

--- a/composenav/src/main/java/com/adamkobus/compose/navigation/ext/NavGraphBuilderExt.kt
+++ b/composenav/src/main/java/com/adamkobus/compose/navigation/ext/NavGraphBuilderExt.kt
@@ -12,6 +12,7 @@ import androidx.navigation.NavBackStackEntry
 import androidx.navigation.NavDeepLink
 import androidx.navigation.NavGraphBuilder
 import androidx.navigation.compose.dialog
+import com.adamkobus.compose.navigation.ComposeNavigation
 import com.adamkobus.compose.navigation.data.NavGraph
 import com.adamkobus.compose.navigation.destination.INavDestination
 import com.google.accompanist.navigation.animation.composable
@@ -32,6 +33,8 @@ fun NavGraphBuilder.composableDestination(
     popExitTransition: (AnimatedContentScope<NavBackStackEntry>.() -> ExitTransition?)? = exitTransition,
     content: @Composable AnimatedVisibilityScope.(NavBackStackEntry) -> Unit
 ) {
+    ComposeNavigation.getNavDestinationManager().addToKnownDestinations(destination)
+
     composable(
         destination.route.buildRoute(),
         arguments = arguments,
@@ -57,6 +60,8 @@ fun NavGraphBuilder.composableNavigation(
     popExitTransition: (AnimatedContentScope<NavBackStackEntry>.() -> ExitTransition?)? = exitTransition,
     builder: NavGraphBuilder.() -> Unit
 ) {
+    ComposeNavigation.getNavDestinationManager().addToKnownDestinations(graph)
+
     navigation(
         route = graph.name,
         startDestination = graph.startDestination().route.buildRoute(),

--- a/composenav/src/main/java/com/adamkobus/compose/navigation/model/NavDestinationManager.kt
+++ b/composenav/src/main/java/com/adamkobus/compose/navigation/model/NavDestinationManager.kt
@@ -38,11 +38,11 @@ class NavDestinationManager internal constructor() {
     }
 
     internal fun addDestinationsFromAction(action: NavAction) {
-        registerDestination(action.fromDestination)
-        registerDestination(action.toDestination)
+        addToKnownDestinations(action.fromDestination)
+        addToKnownDestinations(action.toDestination)
     }
 
-    private fun registerDestination(destination: INavDestination) {
+    internal fun addToKnownDestinations(destination: INavDestination) {
         if (destination is NavGraph) {
             val startDestination = destination.startDestination()
             addKnownDestination(startDestination.route.buildRoute(), startDestination)


### PR DESCRIPTION
### Changes

Before this change, current destination would change from null to splash when navigation to welcome screen was happening.
Example (check timestamps of the logs):

```
2022-02-07 01:55:29.366 (...) D/Navigation: Current destination changed to appGraph/splashScreen
2022-02-07 01:55:29.367 (...) V/Navigation: Started processing: NavAction appGraph/splashScreen -> onBoardingGraph [] | Current destination: appGraph/splashScreen
```

With this change, destination is detected as soon as the user enters Splash screen:

```
2022-02-07 01:56:07.610 (...) D/Navigation: Current destination changed to appGraph/splashScreen
2022-02-07 01:56:08.645 (...) V/Navigation: Started processing: NavAction appGraph/splashScreen -> onBoardingGraph [] | Current destination: appGraph/splashScreen
```

### Testing

Launch the app and check the delay between `Current destination changed to appGraph/splashScreen` and `Started processing: NavAction appGraph/splashScreen -> onBoardingGraph [] | Current destination: appGraph/splashScreen` logs

### Checklist

#### General
- [x] PR targets the `develop` branch
- [x] PR is linked to the GitHub issue it resolves

#### Source code and docs
- [x] Changelog is updated (fixes section for a bug, changes for anything that has been added / modified/ removed)
- [ ] New code is covered by unit tests
- [x] Added ktdoc and updated README.md if API has changed
- [x] Made sure that unit tests pass
- [x] Made sure that `ktlintCheck` and `detekt` tasks produce no issues
- [x] Updated demo app if needed

### Reviewer Checklist
- [x] Library builds
- [x] Demo app works
- [x] Changes work as expected
- [x] Changelog and documentation updates reflect the modification made in this PR
