### PR TITLE
Resolves #41 NavigationProcessor now waits for backstack update before completing action processing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,7 +21,7 @@
 - `NavComposable` now accepts `vararg observedGraphs: NavGraph`. If any NavGraph is provided, then received actions will be filtered only to
   those with `fromDestination` belonging to provided graph(s)
 - Added `NavLogger`
-- Added `NavDestinationManager` - it provides information about current destination
+- Added `NavDestinationManager` - it provides information about current destination and back stack queue
 - Added `ComposeNavigation` which should be used to configure the library and get access to its state
 - Moved documentation to [docs](docs)
 - Names starting with double underscore (i.e. '__myGraph') are now reserved for internal usage. 

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ repositories {
 }
 
 dependencies {
-    implementation "com.adamkobus:compose-navigation:0.1.7-SNAPSHOT"
+    implementation "com.adamkobus:compose-navigation:0.1.8-SNAPSHOT"
 }
 ```
 

--- a/composenav/src/main/java/com/adamkobus/compose/navigation/NavActionVerifier.kt
+++ b/composenav/src/main/java/com/adamkobus/compose/navigation/NavActionVerifier.kt
@@ -2,7 +2,7 @@ package com.adamkobus.compose.navigation
 
 import com.adamkobus.compose.navigation.action.NavAction
 import com.adamkobus.compose.navigation.action.NavigateAction
-import com.adamkobus.compose.navigation.destination.INavDestination
+import com.adamkobus.compose.navigation.destination.CurrentDestination
 
 /**
  * Purpose of this class is to verify if [NavigateAction] execution is allowed based on the application state.
@@ -15,12 +15,15 @@ interface NavActionVerifier {
 
     /**
      * @param currentDestination Represents the destination displayed to the user at the moment of performing this check
-     * @param action Action that was produced via [NavigationState.postNavAction]
+     * @param action Action that was produced via [NavActionConsumer.offer]
      *
      * @return [VerifyResult.Discard] if [action] should be discarded.
      * [VerifyResult.Allow] should be returned if this [NavActionVerifier] doesn't want to block the [action]
+     *
+     * @see [CurrentDestination]
+     * @see [NavAction]
      */
-    fun isNavActionAllowed(currentDestination: INavDestination, action: NavAction): VerifyResult
+    fun isNavActionAllowed(currentDestination: CurrentDestination, action: NavAction): VerifyResult
 }
 
 enum class VerifyResult {

--- a/composenav/src/main/java/com/adamkobus/compose/navigation/NavigationStateSource.kt
+++ b/composenav/src/main/java/com/adamkobus/compose/navigation/NavigationStateSource.kt
@@ -1,10 +1,10 @@
 package com.adamkobus.compose.navigation
 
-import com.adamkobus.compose.navigation.destination.INavDestination
+import com.adamkobus.compose.navigation.destination.CurrentDestination
 import kotlinx.coroutines.flow.Flow
 
 interface NavigationStateSource {
-    val currentDestination: INavDestination?
+    val currentDestination: CurrentDestination
 
-    fun observeCurrentDestination(): Flow<INavDestination?>
+    fun observeCurrentDestination(): Flow<CurrentDestination>
 }

--- a/composenav/src/main/java/com/adamkobus/compose/navigation/data/NavGraph.kt
+++ b/composenav/src/main/java/com/adamkobus/compose/navigation/data/NavGraph.kt
@@ -48,6 +48,6 @@ abstract class NavGraph internal constructor(
     infix fun to(other: NavGraph): NavigateAction = NavigateAction(this, other)
 
     override fun toString(): String {
-        return "Graph($name) ${startDestination()}"
+        return "Graph($name)"
     }
 }

--- a/composenav/src/main/java/com/adamkobus/compose/navigation/data/UnknownGraph.kt
+++ b/composenav/src/main/java/com/adamkobus/compose/navigation/data/UnknownGraph.kt
@@ -1,0 +1,7 @@
+package com.adamkobus.compose.navigation.data
+
+import com.adamkobus.compose.navigation.destination.INavDestination
+
+object UnknownGraph : NavGraph("__unknown__", reservedNameCheck = false) {
+    override fun startDestination(): INavDestination = navDestination("__unknown__")
+}

--- a/composenav/src/main/java/com/adamkobus/compose/navigation/destination/CurrentDestination.kt
+++ b/composenav/src/main/java/com/adamkobus/compose/navigation/destination/CurrentDestination.kt
@@ -1,0 +1,6 @@
+package com.adamkobus.compose.navigation.destination
+
+data class CurrentDestination(
+    val destination: INavDestination?,
+    val backStack: List<INavDestination>
+)

--- a/composenav/src/main/java/com/adamkobus/compose/navigation/destination/NavDestination.kt
+++ b/composenav/src/main/java/com/adamkobus/compose/navigation/destination/NavDestination.kt
@@ -28,7 +28,7 @@ data class NavDestination(
     infix fun to(other: DialogDestination) = NavigateAction(this, other)
 
     override fun toString(): String {
-        return route.buildRoute()
+        return "Destination(${route.buildRoute()})"
     }
 }
 

--- a/composenav/src/main/java/com/adamkobus/compose/navigation/destination/UnknownDestination.kt
+++ b/composenav/src/main/java/com/adamkobus/compose/navigation/destination/UnknownDestination.kt
@@ -1,0 +1,12 @@
+package com.adamkobus.compose.navigation.destination
+
+import com.adamkobus.compose.navigation.data.NavGraph
+import com.adamkobus.compose.navigation.data.UnknownGraph
+
+class UnknownDestination internal constructor(val path: String) : INavDestination {
+    override val graph: NavGraph = UnknownGraph
+
+    override val route: NavRoute = navRoute(graphName = graph.name, path = path, reservedNamesCheck = false)
+
+    override fun toString(): String = "Unknown($path)"
+}

--- a/composenav/src/main/java/com/adamkobus/compose/navigation/model/NavGatekeeper.kt
+++ b/composenav/src/main/java/com/adamkobus/compose/navigation/model/NavGatekeeper.kt
@@ -3,13 +3,13 @@ package com.adamkobus.compose.navigation.model
 import com.adamkobus.compose.navigation.NavActionVerifier
 import com.adamkobus.compose.navigation.VerifyResult
 import com.adamkobus.compose.navigation.action.NavAction
-import com.adamkobus.compose.navigation.destination.INavDestination
+import com.adamkobus.compose.navigation.destination.CurrentDestination
 import javax.inject.Inject
 
 internal class NavGatekeeper @Inject constructor(
     private val verifiers: Set<@JvmSuppressWildcards NavActionVerifier>
 ) {
-    fun isNavActionAllowed(currentDestination: INavDestination, action: NavAction): Boolean {
+    fun isNavActionAllowed(currentDestination: CurrentDestination, action: NavAction): Boolean {
         verifiers.forEach {
             if (it.isNavActionAllowed(currentDestination, action) == VerifyResult.Discard) {
                 return false

--- a/composenav/src/main/java/com/adamkobus/compose/navigation/model/StubActionVerifier.kt
+++ b/composenav/src/main/java/com/adamkobus/compose/navigation/model/StubActionVerifier.kt
@@ -3,10 +3,10 @@ package com.adamkobus.compose.navigation.model
 import com.adamkobus.compose.navigation.NavActionVerifier
 import com.adamkobus.compose.navigation.VerifyResult
 import com.adamkobus.compose.navigation.action.NavAction
-import com.adamkobus.compose.navigation.destination.INavDestination
+import com.adamkobus.compose.navigation.destination.CurrentDestination
 import javax.inject.Inject
 
 internal class StubActionVerifier @Inject constructor() : NavActionVerifier {
 
-    override fun isNavActionAllowed(currentDestination: INavDestination, action: NavAction): VerifyResult = VerifyResult.Allow
+    override fun isNavActionAllowed(currentDestination: CurrentDestination, action: NavAction): VerifyResult = VerifyResult.Allow
 }

--- a/composenav/src/main/java/com/adamkobus/compose/navigation/ui/NavComposable.kt
+++ b/composenav/src/main/java/com/adamkobus/compose/navigation/ui/NavComposable.kt
@@ -31,6 +31,6 @@ fun NavComposable(
     }
     val currentBackStackEntry = navController.currentBackStackEntryFlow.collectAsState(initial = null)
     LaunchedEffect(key1 = currentBackStackEntry.value) {
-        vm.processBackStackEntry(currentBackStackEntry.value)
+        vm.processBackStackEntry(currentBackStackEntry.value, navController.backQueue)
     }
 }

--- a/composenav/src/main/java/com/adamkobus/compose/navigation/ui/NavComposableVM.kt
+++ b/composenav/src/main/java/com/adamkobus/compose/navigation/ui/NavComposableVM.kt
@@ -50,7 +50,7 @@ internal class NavComposableVM @Inject constructor(
         navigationProcessor.unregister(this)
     }
 
-    fun processBackStackEntry(entry: NavBackStackEntry?) {
-        navigationProcessor.onBackStackEntryUpdated(entry)
+    fun processBackStackEntry(entry: NavBackStackEntry?, backQueue: List<NavBackStackEntry>) {
+        navigationProcessor.onBackStackEntryUpdated(entry, backQueue)
     }
 }

--- a/composenav/src/test/java/com/adamkobus/compose/navigation/model/NavGatekeeperTest.kt
+++ b/composenav/src/test/java/com/adamkobus/compose/navigation/model/NavGatekeeperTest.kt
@@ -3,7 +3,7 @@ package com.adamkobus.compose.navigation.model
 import com.adamkobus.compose.navigation.NavActionVerifier
 import com.adamkobus.compose.navigation.VerifyResult
 import com.adamkobus.compose.navigation.action.NavigateAction
-import com.adamkobus.compose.navigation.destination.INavDestination
+import com.adamkobus.compose.navigation.destination.CurrentDestination
 import io.mockk.every
 import io.mockk.mockk
 import junit.framework.TestCase.assertFalse
@@ -61,7 +61,7 @@ class NavGatekeeperTest {
         }
 
     companion object {
-        private val NAV_DESTINATION = mockk<INavDestination>()
+        private val NAV_DESTINATION = mockk<CurrentDestination>()
         private val NAV_ACTION = mockk<NavigateAction>()
     }
 }

--- a/demo/src/main/java/com/adamkobus/compose/navigation/demo/nav/AppNavActionVerifier.kt
+++ b/demo/src/main/java/com/adamkobus/compose/navigation/demo/nav/AppNavActionVerifier.kt
@@ -4,13 +4,13 @@ import com.adamkobus.compose.navigation.NavActionVerifier
 import com.adamkobus.compose.navigation.VerifyResult
 import com.adamkobus.compose.navigation.action.NavAction
 import com.adamkobus.compose.navigation.data.GlobalGraph
-import com.adamkobus.compose.navigation.destination.INavDestination
+import com.adamkobus.compose.navigation.destination.CurrentDestination
 import javax.inject.Inject
 
 class AppNavActionVerifier @Inject constructor() : NavActionVerifier {
-    override fun isNavActionAllowed(currentDestination: INavDestination, action: NavAction): VerifyResult {
+    override fun isNavActionAllowed(currentDestination: CurrentDestination, action: NavAction): VerifyResult {
         if (action.fromDestination.graph == GlobalGraph) return VerifyResult.Allow
-        return if (currentDestination == action.fromDestination) {
+        return if (currentDestination.destination == action.fromDestination) {
             VerifyResult.Allow
         } else {
             VerifyResult.Discard

--- a/demo/src/main/java/com/adamkobus/compose/navigation/demo/ui/tabhost/DemoTabsNavigationVM.kt
+++ b/demo/src/main/java/com/adamkobus/compose/navigation/demo/ui/tabhost/DemoTabsNavigationVM.kt
@@ -7,7 +7,7 @@ import com.adamkobus.compose.navigation.NavActionConsumer
 import com.adamkobus.compose.navigation.NavigationStateSource
 import com.adamkobus.compose.navigation.demo.ui.nav.CatsBrowserGraph
 import com.adamkobus.compose.navigation.demo.ui.nav.DogsBrowserGraph
-import com.adamkobus.compose.navigation.destination.INavDestination
+import com.adamkobus.compose.navigation.destination.CurrentDestination
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.launch
 import javax.inject.Inject
@@ -49,7 +49,8 @@ class DemoTabsNavigationVM @Inject constructor(
         }
     }
 
-    private fun processNavigationUpdate(destination: INavDestination?) {
+    private fun processNavigationUpdate(currentDestination: CurrentDestination) {
+        val destination = currentDestination.destination
         if (destination in CATS_DESTINATIONS) {
             onCatActive()
         } else if (destination in DOGS_DESTINATIONS) {
@@ -74,13 +75,14 @@ class DemoTabsNavigationVM @Inject constructor(
     }
 
     private fun processTabSelection(tabData: DemoTabData) {
+        // TODO replace with intent
         when (tabData) {
-            DemoTabs.Cats -> if (navigationStateSource.currentDestination in CATS_DESTINATIONS) {
+            DemoTabs.Cats -> if (navigationStateSource.currentDestination.destination in CATS_DESTINATIONS) {
                 navActionConsumer.offer(DemoTabHostActions.ToCatsRoot)
             } else {
                 navActionConsumer.offer(DemoTabHostActions.FromGlobalToCats)
             }
-            DemoTabs.Dogs -> if (navigationStateSource.currentDestination in DOGS_DESTINATIONS) {
+            DemoTabs.Dogs -> if (navigationStateSource.currentDestination.destination in DOGS_DESTINATIONS) {
                 navActionConsumer.offer(DemoTabHostActions.ToDogsRoot)
             } else {
                 navActionConsumer.offer(DemoTabHostActions.FromGlobalToDogs)

--- a/gradle/version.gradle
+++ b/gradle/version.gradle
@@ -1,4 +1,4 @@
-def VERSION_BASE = "0.1.7"
+def VERSION_BASE = "0.1.8"
 
 rootProject.readParam("mavenSnapshot", true)
 


### PR DESCRIPTION
### Changes

NavigationProcessor will complete nav action only after it receives updated back stack from the NacComposable
Added `CurrentDestination` object that includes buth, current destination and back stack queue.

### Testing

By going through the demo application and checking logs.

### Checklist

#### General
- [x] PR targets the `develop` branch
- [x] PR is linked to the GitHub issue it resolves

#### Source code and docs
- [x] Changelog is updated (fixes section for a bug, changes for anything that has been added / modified/ removed)
- [ ] New code is covered by unit tests
- [ ] Added ktdoc and updated README.md if API has changed
- [x] Made sure that unit tests pass
- [x] Made sure that `ktlintCheck` and `detekt` tasks produce no issues
- [x] Updated demo app if needed

### Reviewer Checklist
- [x] Library builds
- [x] Demo app works
- [x] Changes work as expected
- [x] Changelog and documentation updates reflect the modification made in this PR
