### PR TITLE
Fixes #87 Custom NavigationId now works properly

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ repositories {
 }
 
 dependencies {
-    implementation "com.adamkobus:compose-navigation:0.2.6-SNAPSHOT"
+    implementation "com.adamkobus:compose-navigation:0.2.7-SNAPSHOT"
 }
 ```
 

--- a/composenav/src/main/java/com/adamkobus/compose/navigation/ui/NavComposableVM.kt
+++ b/composenav/src/main/java/com/adamkobus/compose/navigation/ui/NavComposableVM.kt
@@ -27,7 +27,7 @@ internal class NavComposableVM : LifecycleAwareViewModel(), ActionConsumer {
     internal val pendingActionState = mutableStateOf<PendingActionState>(PendingActionState.Missing)
 
     override var supportedGraphsRoutes: List<String> = emptyList()
-    private var navigationId: NavigationId? = NavigationId.DEFAULT
+    private var navigationId: NavigationId? = null
 
     private val navigationProcessor: NavigationProcessor?
         get() = navigationId?.let { ComposeNavigation.getNavigationProcessor(it) }
@@ -107,14 +107,6 @@ internal class NavComposableVM : LifecycleAwareViewModel(), ActionConsumer {
 
     override suspend fun awaitUntilReady() {
         loadingCompletable?.await()
-    }
-
-    override fun equals(other: Any?): Boolean {
-        return other is NavComposableVM && other.navigationId == navigationId
-    }
-
-    override fun hashCode(): Int {
-        return navigationId?.hashCode() ?: 0
     }
 
     override fun toString(): String = "[$navigationId] NavComposable"

--- a/demo-common-ui/src/main/java/com/adamkobus/compose/navigation/demo/ui/di/NavModule.kt
+++ b/demo-common-ui/src/main/java/com/adamkobus/compose/navigation/demo/ui/di/NavModule.kt
@@ -1,8 +1,8 @@
 package com.adamkobus.compose.navigation.demo.ui.di
 
 import com.adamkobus.compose.navigation.ComposeNavigation
-import com.adamkobus.compose.navigation.NavigationId
 import com.adamkobus.compose.navigation.NavigationStateSource
+import com.adamkobus.compose.navigation.demo.ui.nav.DemoNavigationId
 import dagger.Module
 import dagger.Provides
 import dagger.hilt.InstallIn
@@ -13,5 +13,5 @@ import dagger.hilt.components.SingletonComponent
 object NavModule {
 
     @Provides
-    fun provideNavigationStateSource(): NavigationStateSource = ComposeNavigation.getNavigationStateSource(NavigationId.DEFAULT)
+    fun provideNavigationStateSource(): NavigationStateSource = ComposeNavigation.getNavigationStateSource(DemoNavigationId)
 }

--- a/demo-common-ui/src/main/java/com/adamkobus/compose/navigation/demo/ui/nav/AppGraph.kt
+++ b/demo-common-ui/src/main/java/com/adamkobus/compose/navigation/demo/ui/nav/AppGraph.kt
@@ -1,5 +1,6 @@
 package com.adamkobus.compose.navigation.demo.ui.nav
 
+import com.adamkobus.compose.navigation.NavigationId
 import com.adamkobus.compose.navigation.destination.NavGraph
 import com.adamkobus.compose.navigation.destination.ScreenDestination
 
@@ -8,3 +9,5 @@ object AppGraph : NavGraph("appGraph") {
 
     val SplashScreen = screenDestination("splashScreen")
 }
+
+val DemoNavigationId = NavigationId("demo")

--- a/demo/src/main/java/com/adamkobus/compose/navigation/demo/ui/app/DemoAppRoot.kt
+++ b/demo/src/main/java/com/adamkobus/compose/navigation/demo/ui/app/DemoAppRoot.kt
@@ -10,7 +10,6 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.hilt.navigation.compose.hiltViewModel
 import com.adamkobus.compose.navigation.ComposeNavHost
-import com.adamkobus.compose.navigation.NavigationId
 import com.adamkobus.compose.navigation.demo.nav.appGraph
 import com.adamkobus.compose.navigation.demo.nav.onBoardingGraph
 import com.adamkobus.compose.navigation.demo.nav.petsGraph
@@ -18,6 +17,7 @@ import com.adamkobus.compose.navigation.demo.settings.nav.settingsGraph
 import com.adamkobus.compose.navigation.demo.ui.appbar.AnimatedAppBar
 import com.adamkobus.compose.navigation.demo.ui.appbar.AnimatedAppBarState
 import com.adamkobus.compose.navigation.demo.ui.nav.AppGraph
+import com.adamkobus.compose.navigation.demo.ui.nav.DemoNavigationId
 import com.adamkobus.compose.navigation.demo.ui.tabhost.DemoTabsNavigation
 import com.google.accompanist.navigation.animation.rememberAnimatedNavController
 
@@ -30,7 +30,7 @@ fun DemoAppRoot() {
         ComposeNavHost(
             startGraph = AppGraph,
             controller = controller,
-            navigationId = NavigationId.DEFAULT,
+            navigationId = DemoNavigationId,
             modifier = Modifier.fillMaxSize()
         ) {
             appGraph()

--- a/gradle/version.gradle
+++ b/gradle/version.gradle
@@ -1,4 +1,4 @@
-def VERSION_BASE = "0.2.6"
+def VERSION_BASE = "0.2.7"
 
 rootProject.readParam("mavenSnapshot", true)
 


### PR DESCRIPTION
### Changes

App was freezing because equals method of `NavComposableVM` was returning different values before and after the navigationId param was bound.

### Testing

### Checklist

#### General
- [x] PR targets the `develop` branch
- [x] PR is linked to the GitHub issue it resolves

#### Source code and docs
- [x] Changelog is updated (fixes section for a bug, changes for anything that has been added / modified/ removed)
- [x] New code is covered by unit tests
- [x] Added ktdoc and updated README.md if API has changed
- [x] Made sure that unit tests pass
- [x] Made sure that `ktlintCheck` and `detekt` tasks produce no issues
- [x] Updated demo app if needed

### Reviewer Checklist
- [x] Library builds
- [x] Demo app works
- [x] Changes work as expected
- [x] Changelog and documentation updates reflect the modification made in this PR
