### PR TITLE
Fixes #96 - NavStackEntry is no longer nullable in composableDestination

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,8 @@
 - Added support for nested Nav Hosts
 - NavState now has a list of `NavControllerState`s which gives access to information about all used NavHosts
 - `NavIntent` has an additional field now which is called `navigationId`.
-  It's just for informational purpose and doesn't influence the intents processing.
+  It's just for informational purpose and it doesn't influence the intents processing.
+- #96 `NavStackEntry` is no longer nullable in `composableDestination` lambda
 
 # 0.2.0
 

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ repositories {
 }
 
 dependencies {
-    implementation "com.adamkobus:compose-navigation:0.2.10-SNAPSHOT"
+    implementation "com.adamkobus:compose-navigation:0.2.11-SNAPSHOT"
 }
 ```
 

--- a/composenav/src/main/java/com/adamkobus/compose/navigation/model/KnownDestinationsSource.kt
+++ b/composenav/src/main/java/com/adamkobus/compose/navigation/model/KnownDestinationsSource.kt
@@ -3,7 +3,6 @@ package com.adamkobus.compose.navigation.model
 import android.os.Bundle
 import androidx.navigation.NavBackStackEntry
 import com.adamkobus.compose.navigation.ComposeNavigation
-import com.adamkobus.compose.navigation.action.NavAction
 import com.adamkobus.compose.navigation.destination.INavDestination
 import com.adamkobus.compose.navigation.destination.NavDestination
 import com.adamkobus.compose.navigation.destination.NavStackEntry
@@ -12,11 +11,6 @@ import com.adamkobus.compose.navigation.destination.UnknownDestination
 internal class KnownDestinationsSource {
 
     private val knownDestinations = mutableMapOf<String, NavDestination>()
-
-    internal fun addDestinationsFromAction(action: NavAction) {
-        addToKnownDestinations(action.fromDestination)
-        addToKnownDestinations(action.toDestination)
-    }
 
     internal fun addToKnownDestinations(destination: INavDestination) {
         if (destination is NavDestination) {
@@ -32,19 +26,20 @@ internal class KnownDestinationsSource {
         }
     }
 
-    internal fun resolveRouteToDestination(route: String?): NavDestination? =
-        route?.let {
+    internal fun resolveRouteToDestination(route: String): NavDestination =
+        route.let {
             knownDestinations[route] ?: UnknownDestination(it)
         }
 }
 
 internal fun NavBackStackEntry.toNavStackEntry(
     knownDestinationsSource: KnownDestinationsSource = ComposeNavigation.getKnownDestinationsSource()
-): NavStackEntry? =
+): NavStackEntry =
     this.let { entry ->
-        entry.destination.route.let { route ->
+        // Compose library is setting routes for all of the destinations, so there is no risk that this would be null.
+        entry.destination.route!!.let { route ->
             knownDestinationsSource.resolveRouteToDestination(route)
-        }?.let { destination ->
+        }.let { destination ->
             NavStackEntry(
                 destination = destination,
                 arguments = buildArguments(destination, entry.arguments)

--- a/composenav/src/main/java/com/adamkobus/compose/navigation/model/NavStateManager.kt
+++ b/composenav/src/main/java/com/adamkobus/compose/navigation/model/NavStateManager.kt
@@ -27,7 +27,12 @@ internal class NavStateManager : NavigationStateSource {
 
     internal fun onBackStackUpdated(navigationId: NavigationId, entry: NavBackStackEntry?, backQueue: List<NavBackStackEntry>) {
         val backStack = backQueue.mapNotNull {
-            it.toNavStackEntry()
+            if (it.destination.id == 0 && it.destination.route == null) {
+                // this is the app's root graph that is not part of the navigation tree
+                null
+            } else {
+                it.toNavStackEntry()
+            }
         }
         updateCurrentDestination(NavControllerState(navigationId, entry?.toNavStackEntry(), backStack))
     }

--- a/gradle/version.gradle
+++ b/gradle/version.gradle
@@ -1,4 +1,4 @@
-def VERSION_BASE = "0.2.10"
+def VERSION_BASE = "0.2.11"
 
 rootProject.readParam("mavenSnapshot", true)
 


### PR DESCRIPTION
### Changes

NavStackEntry is no longer nullable in composableDestination

### Testing

### Checklist

#### General
- [x] PR targets the `develop` branch
- [x] PR is linked to the GitHub issue it resolves

#### Source code and docs
- [x] Changelog is updated (fixes section for a bug, changes for anything that has been added / modified/ removed)
- [ ] New code is covered by unit tests
- [x] Added ktdoc and updated README.md if API has changed
- [x] Made sure that unit tests pass
- [x] Made sure that `ktlintCheck` and `detekt` tasks produce no issues
- [x] Updated demo app if needed

### Reviewer Checklist
- [x] Library builds
- [x] Demo app works
- [x] Changes work as expected
- [x] Changelog and documentation updates reflect the modification made in this PR
