### PR TITLE
Fix to maven publishing config after plugin update

### DIFF
--- a/gradle/publishing-module.gradle
+++ b/gradle/publishing-module.gradle
@@ -1,20 +1,14 @@
 apply plugin: 'maven-publish'
 apply plugin: 'signing'
 
-task androidSourcesJar(type: Jar) {
-    archiveClassifier.set('sources')
-    if (project.plugins.findPlugin("com.android.library")) {
-        from android.sourceSets.main.java.srcDirs
-        from android.sourceSets.main.kotlin.srcDirs
-    } else {
-        from sourceSets.main.java.srcDirs
-        from sourceSets.main.kotlin.srcDirs
+android {
+    publishing {
+        singleVariant("release") {
+            withSourcesJar()
+        }
     }
 }
 
-artifacts {
-    archives androidSourcesJar
-}
 
 group = PUBLISH_GROUP_ID
 version = rootProject.PUBLISH_VERSION
@@ -23,17 +17,11 @@ afterEvaluate {
     publishing {
         publications {
             release(MavenPublication) {
+                from components.release
+
                 groupId PUBLISH_GROUP_ID
                 artifactId PUBLISH_ARTIFACT_ID
                 version rootProject.PUBLISH_VERSION
-
-                if (project.plugins.findPlugin("com.android.library")) {
-                    from components.release
-                } else {
-                    from components.java
-                }
-
-                artifact androidSourcesJar
 
                 pom {
                     name = "Android Compose Navigation"


### PR DESCRIPTION
### Changes

New version of maven-publish plugin requires different artifacts configuration approach. `publishing-module.gradle` was updated to refrlect those new requirements.

### Testing

Was able to reproduce the issue with `publishToMavenLocal`. It works after the changes in this PR.

### Checklist

#### General
- [x] PR targets the `develop` branch
- [ ] PR is linked to the GitHub issue it resolves

#### Source code and docs
- [ ] Changelog is updated (fixes section for a bug, changes for anything that has been added / modified/ removed)
- [ ] New code is covered by unit tests
- [ ] Added ktdoc and updated README.md if API has changed
- [ ] Made sure that unit tests pass
- [ ] Made sure that `ktlintCheck` and `detekt` tasks produce no issues
- [ ] Updated demo app if needed

### Reviewer Checklist
- [ ] Library builds
- [ ] Demo app works
- [ ] Changes work as expected
- [ ] Changelog and documentation updates reflect the modification made in this PR
