### PR TITLE
Removed explicit androidSourcesJar task execution in GH workflows

### DIFF
--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -31,9 +31,6 @@ jobs:
       - name: Build project
         run: ./gradlew clean :composenav:assembleRelease
 
-      - name: Create source jar
-        run: ./gradlew :composenav:androidSourcesJar
-
       - name: Publish to MavenCentral
         run: ./gradlew publishReleasePublicationToSonatypeRepository closeAndReleaseSonatypeStagingRepository --max-workers 1
 

--- a/.github/workflows/publish-snapshot.yml
+++ b/.github/workflows/publish-snapshot.yml
@@ -28,9 +28,6 @@ jobs:
       - name: Build project
         run: ./gradlew clean :composenav:assembleRelease
 
-      - name: Create source jar
-        run: ./gradlew :composenav:androidSourcesJar
-
       - name: Publish to MavenCentral
         run: ./gradlew :composenav:publishReleasePublicationToSonatypeRepository
         env:


### PR DESCRIPTION
### Changes

Forgotten there is an explicit invocation of `androidSourcesJar` task in certain workflows. Removed those steps

### Testing

will test after merge :)

### Checklist

#### General
- [ ] PR targets the `develop` branch
- [ ] PR is linked to the GitHub issue it resolves

#### Source code and docs
- [ ] Changelog is updated (fixes section for a bug, changes for anything that has been added / modified/ removed)
- [ ] New code is covered by unit tests
- [ ] Added ktdoc and updated README.md if API has changed
- [ ] Made sure that unit tests pass
- [ ] Made sure that `ktlintCheck` and `detekt` tasks produce no issues
- [ ] Updated demo app if needed

### Reviewer Checklist
- [ ] Library builds
- [ ] Demo app works
- [ ] Changes work as expected
- [ ] Changelog and documentation updates reflect the modification made in this PR
